### PR TITLE
Observable.create() 사용 회피

### DIFF
--- a/api/src/main/java/org/petabytes/api/source/local/AwesomeBlogsLocalSource.java
+++ b/api/src/main/java/org/petabytes/api/source/local/AwesomeBlogsLocalSource.java
@@ -11,8 +11,8 @@ import io.realm.RealmConfiguration;
 import io.realm.RealmMigration;
 import io.realm.RealmResults;
 import rx.Observable;
-import rx.Subscriber;
 import rx.functions.Action0;
+import rx.functions.Func0;
 import rx.functions.Func1;
 
 public class AwesomeBlogsLocalSource implements DataSource {
@@ -26,14 +26,16 @@ public class AwesomeBlogsLocalSource implements DataSource {
 
     @Override
     public Observable<Feed> getFeed(@NonNull final String category) {
-        return Observable.create(new Observable.OnSubscribe<Feed>() {
+        return Observable.fromCallable(new Func0<Feed>() {
             @Override
-            public void call(Subscriber<? super Feed> subscriber) {
+            public Feed call() {
                 Realm realm = Realm.getInstance(config);
-                Feed feed = realm.where(Feed.class).equalTo("category", category).findFirst();
-                subscriber.onNext(feed != null ? realm.copyFromRealm(feed) : null);
-                subscriber.onCompleted();
-                realm.close();
+                try {
+                    Feed feed = realm.where(Feed.class).equalTo("category", category).findFirst();
+                    return feed != null ? realm.copyFromRealm(feed) : null;
+                } finally {
+                    realm.close();
+                }
             }
         });
     }


### PR DESCRIPTION
RxJava 1.x 의 `Observable.create()` 는 사용을 제한하기 때문에 보다 안전한 방법인 `Observable.fromCallable()` 을 사용