### PR TITLE
Observable.create() 사용 회피

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -16,6 +16,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         debug {
@@ -25,6 +26,12 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    configurations.all {
+        resolutionStrategy {
+            force rootProject.ext.support_annotation
         }
     }
 }
@@ -40,4 +47,7 @@ dependencies {
     compile rootProject.ext.retrofit_gsonconverter
     compile rootProject.ext.retrofit_logging
     testCompile rootProject.ext.junit
+    androidTestCompile rootProject.ext.testrunner
+    androidTestCompile rootProject.ext.espresso_core
+    androidTestCompile rootProject.ext.assertj
 }

--- a/api/src/androidTest/java/org/petabytes/api/source/local/AwesomeBlogsLocalSourceTest.java
+++ b/api/src/androidTest/java/org/petabytes/api/source/local/AwesomeBlogsLocalSourceTest.java
@@ -1,0 +1,72 @@
+package org.petabytes.api.source.local;
+
+import android.support.test.InstrumentationRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import io.realm.Realm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@org.junit.runner.RunWith(android.support.test.runner.AndroidJUnit4.class)
+public class AwesomeBlogsLocalSourceTest {
+
+    private AwesomeBlogsLocalSource localSource;
+
+    @Before
+    public void setUp() throws Exception {
+        localSource = new AwesomeBlogsLocalSource(InstrumentationRegistry.getContext());
+    }
+
+    @Test
+    public void getFeed() throws Exception {
+        {
+            Realm.getInstance(localSource.config)
+                    .executeTransaction(new Realm.Transaction() {
+                        @Override
+                        public void execute(Realm realm) {
+                            realm.deleteAll();
+                        }
+                    });
+            List<Feed> values = localSource.getFeed("dev")
+                    .test()
+                    .awaitTerminalEvent()
+                    .assertCompleted()
+                    .getOnNextEvents();
+
+            assertThat(values)
+                    .hasSize(1)
+                    .containsNull();
+        }
+
+        {
+            Feed feed = new Feed();
+            feed.setCategory("dev");
+            Realm.getInstance(localSource.config)
+                    .executeTransaction(new Realm.Transaction() {
+                        @Override
+                        public void execute(Realm realm) {
+                            Feed feed = new Feed();
+                            feed.setCategory("dev");
+                            realm.insert(feed);
+                        }
+                    });
+
+            List<Feed> values = localSource.getFeed("dev")
+                    .test()
+                    .awaitTerminalEvent()
+                    .assertCompleted()
+                    .getOnNextEvents();
+
+            assertThat(values)
+                    .hasSize(1)
+                    .extracting("category")
+                    .contains("dev");
+        }
+
+
+    }
+}

--- a/api/src/main/java/org/petabytes/api/source/local/AwesomeBlogsLocalSource.java
+++ b/api/src/main/java/org/petabytes/api/source/local/AwesomeBlogsLocalSource.java
@@ -11,8 +11,8 @@ import io.realm.RealmConfiguration;
 import io.realm.RealmMigration;
 import io.realm.RealmResults;
 import rx.Observable;
-import rx.Subscriber;
 import rx.functions.Action0;
+import rx.functions.Func0;
 import rx.functions.Func1;
 
 public class AwesomeBlogsLocalSource implements DataSource {
@@ -26,14 +26,16 @@ public class AwesomeBlogsLocalSource implements DataSource {
 
     @Override
     public Observable<Feed> getFeed(@NonNull final String category) {
-        return Observable.create(new Observable.OnSubscribe<Feed>() {
+        return Observable.fromCallable(new Func0<Feed>() {
             @Override
-            public void call(Subscriber<? super Feed> subscriber) {
+            public Feed call() {
                 Realm realm = Realm.getInstance(config);
-                Feed feed = realm.where(Feed.class).equalTo("category", category).findFirst();
-                subscriber.onNext(feed != null ? realm.copyFromRealm(feed) : null);
-                subscriber.onCompleted();
-                realm.close();
+                try {
+                    Feed feed = realm.where(Feed.class).equalTo("category", category).findFirst();
+                    return feed != null ? realm.copyFromRealm(feed) : null;
+                } finally {
+                    realm.close();
+                }
             }
         });
     }

--- a/api/src/main/java/org/petabytes/api/source/local/AwesomeBlogsLocalSource.java
+++ b/api/src/main/java/org/petabytes/api/source/local/AwesomeBlogsLocalSource.java
@@ -2,6 +2,7 @@ package org.petabytes.api.source.local;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 
 import org.petabytes.api.DataSource;
 
@@ -17,7 +18,8 @@ import rx.functions.Func1;
 
 public class AwesomeBlogsLocalSource implements DataSource {
 
-    private final RealmConfiguration config;
+    @VisibleForTesting
+    final RealmConfiguration config;
 
     public AwesomeBlogsLocalSource(@NonNull Context context) {
         Realm.init(context);
@@ -102,4 +104,5 @@ public class AwesomeBlogsLocalSource implements DataSource {
         }
         return builder.build();
     }
+
 }

--- a/dependencies-variable.gradle
+++ b/dependencies-variable.gradle
@@ -48,4 +48,12 @@ ext {
 
     assertj = 'org.assertj:assertj-core:1.7.1'
     junit = 'junit:junit:4.12'
+
+    testrunner = 'com.android.support.test:runner:0.5'
+    testrule = 'com.android.support.test:rules:0.5'
+    espresso_core = 'com.android.support.test.espresso:espresso-core:2.2.2'
+    espresso_intent = 'com.android.support.test.espresso:espresso-intents:2.2.2'
+    dexmaker_mockito = 'com.crittercism.dexmaker:dexmaker-mockito:1.4'
+    dexmaker_dx = 'com.crittercism.dexmaker:dexmaker-dx:1.4'
+    mockito = 'org.mockito:mockito-core:1.10.19'
 }


### PR DESCRIPTION
Observable.create() 사용 회피

* RxJava 1.x 의 Observable.create() 는 사용을 제한하기 때문에 보다 안전한 방법인 Observable.fromCallable() 을 사용

* 이전과 동일하게 동작하는지 확인하기 위한 test 코드 추가