### PR TITLE
api.getFeed 에서 null emit 상황 제거

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     compile rootProject.ext.retrofit_gsonconverter
     compile rootProject.ext.retrofit_logging
     testCompile rootProject.ext.junit
+    testCompile rootProject.ext.assertj
+    testCompile rootProject.ext.mockito
     androidTestCompile rootProject.ext.testrunner
     androidTestCompile rootProject.ext.espresso_core
     androidTestCompile rootProject.ext.assertj

--- a/api/src/androidTest/java/org/petabytes/api/source/local/AwesomeBlogsLocalSourceTest.java
+++ b/api/src/androidTest/java/org/petabytes/api/source/local/AwesomeBlogsLocalSourceTest.java
@@ -25,48 +25,46 @@ public class AwesomeBlogsLocalSourceTest {
     public void getFeed() throws Exception {
         {
             Realm.getInstance(localSource.config)
-                    .executeTransaction(new Realm.Transaction() {
-                        @Override
-                        public void execute(Realm realm) {
-                            realm.deleteAll();
-                        }
-                    });
+                .executeTransaction(new Realm.Transaction() {
+                    @Override
+                    public void execute(Realm realm) {
+                        realm.deleteAll();
+                    }
+                });
             List<Feed> values = localSource.getFeed("dev")
-                    .test()
-                    .awaitTerminalEvent()
-                    .assertCompleted()
-                    .getOnNextEvents();
+                .test()
+                .awaitTerminalEvent()
+                .assertCompleted()
+                .getOnNextEvents();
 
             assertThat(values)
-                    .hasSize(1)
-                    .containsNull();
+                .hasSize(1)
+                .containsNull();
         }
 
         {
             Feed feed = new Feed();
             feed.setCategory("dev");
             Realm.getInstance(localSource.config)
-                    .executeTransaction(new Realm.Transaction() {
-                        @Override
-                        public void execute(Realm realm) {
-                            Feed feed = new Feed();
-                            feed.setCategory("dev");
-                            realm.insert(feed);
-                        }
-                    });
+                .executeTransaction(new Realm.Transaction() {
+                    @Override
+                    public void execute(Realm realm) {
+                        Feed feed = new Feed();
+                        feed.setCategory("dev");
+                        realm.insert(feed);
+                    }
+                });
 
             List<Feed> values = localSource.getFeed("dev")
-                    .test()
-                    .awaitTerminalEvent()
-                    .assertCompleted()
-                    .getOnNextEvents();
+                .test()
+                .awaitTerminalEvent()
+                .assertCompleted()
+                .getOnNextEvents();
 
             assertThat(values)
-                    .hasSize(1)
-                    .extracting("category")
-                    .contains("dev");
+                .hasSize(1)
+                .extracting("category")
+                .contains("dev");
         }
-
-
     }
 }

--- a/api/src/main/java/org/petabytes/api/Api.java
+++ b/api/src/main/java/org/petabytes/api/Api.java
@@ -2,21 +2,26 @@ package org.petabytes.api;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import org.petabytes.api.source.local.AwesomeBlogsLocalSource;
 import org.petabytes.api.source.local.Feed;
 import org.petabytes.api.source.remote.AwesomeBlogsRemoteSource;
 
 import rx.Observable;
-import rx.functions.Action0;
 import rx.functions.Action1;
-import rx.functions.Func1;
+import rx.functions.Func0;
 
 public class Api implements DataSource {
 
     private final AwesomeBlogsLocalSource localSource;
     private final AwesomeBlogsRemoteSource remoteSource;
+
+    @VisibleForTesting
+    public Api(AwesomeBlogsLocalSource localSource, AwesomeBlogsRemoteSource remoteSource) {
+        this.localSource = localSource;
+        this.remoteSource = remoteSource;
+    }
 
     public Api(@NonNull Context context, boolean loggable) {
         localSource = new AwesomeBlogsLocalSource(context);
@@ -31,20 +36,20 @@ public class Api implements DataSource {
     @Override
     public Observable<Feed> getFeed(@NonNull final String category) {
         return localSource.getFeed(category)
-            .flatMap(new Func1<Feed, Observable<Feed>>() {
+            .doOnNext(new Action1<Feed>() {
                 @Override
-                public Observable<Feed> call(@Nullable Feed feed) {
-                    return feed != null ? Observable.just(feed)
-                        .doOnTerminate(new Action0() {
-                            @Override
-                            public void call() {
-                                remoteSource.getFeed(category)
-                                    .onErrorResumeNext(Observable.<Feed>empty())
-                                    .subscribe();
-                            }
-                        }) : remoteSource.getFeed(category);
+                public void call(Feed data) {
+                    remoteSource.getFeed(category)
+                        .onErrorResumeNext(Observable.<Feed>empty())
+                        .subscribe();
                 }
-            });
+            })
+            .switchIfEmpty(Observable.defer(new Func0<Observable<Feed>>() {
+                @Override
+                public Observable<Feed> call() {
+                    return remoteSource.getFeed(category);
+                }
+            }));
     }
 
     public Observable<Boolean> isRead(@NonNull String link) {

--- a/api/src/main/java/org/petabytes/api/Api.java
+++ b/api/src/main/java/org/petabytes/api/Api.java
@@ -10,7 +10,6 @@ import org.petabytes.api.source.remote.AwesomeBlogsRemoteSource;
 
 import rx.Observable;
 import rx.functions.Action1;
-import rx.functions.Func0;
 
 public class Api implements DataSource {
 
@@ -44,12 +43,7 @@ public class Api implements DataSource {
                         .subscribe();
                 }
             })
-            .switchIfEmpty(Observable.defer(new Func0<Observable<Feed>>() {
-                @Override
-                public Observable<Feed> call() {
-                    return remoteSource.getFeed(category);
-                }
-            }));
+            .switchIfEmpty(remoteSource.getFeed(category));
     }
 
     public Observable<Boolean> isRead(@NonNull String link) {

--- a/api/src/main/java/org/petabytes/api/Api.java
+++ b/api/src/main/java/org/petabytes/api/Api.java
@@ -18,7 +18,7 @@ public class Api implements DataSource {
     private final AwesomeBlogsRemoteSource remoteSource;
 
     @VisibleForTesting
-    public Api(AwesomeBlogsLocalSource localSource, AwesomeBlogsRemoteSource remoteSource) {
+    Api(AwesomeBlogsLocalSource localSource, AwesomeBlogsRemoteSource remoteSource) {
         this.localSource = localSource;
         this.remoteSource = remoteSource;
     }

--- a/api/src/main/java/org/petabytes/api/source/local/AwesomeBlogsLocalSource.java
+++ b/api/src/main/java/org/petabytes/api/source/local/AwesomeBlogsLocalSource.java
@@ -28,13 +28,13 @@ public class AwesomeBlogsLocalSource implements DataSource {
 
     @Override
     public Observable<Feed> getFeed(@NonNull final String category) {
-        return Observable.fromCallable(new Func0<Feed>() {
+        return Observable.defer(new Func0<Observable<Feed>>() {
             @Override
-            public Feed call() {
+            public Observable<Feed> call() {
                 Realm realm = Realm.getInstance(config);
                 try {
                     Feed feed = realm.where(Feed.class).equalTo("category", category).findFirst();
-                    return feed != null ? realm.copyFromRealm(feed) : null;
+                    return feed != null ? Observable.just(realm.copyFromRealm(feed)) : Observable.<Feed>empty();
                 } finally {
                     realm.close();
                 }

--- a/api/src/test/java/org/petabytes/api/ApiTest.java
+++ b/api/src/test/java/org/petabytes/api/ApiTest.java
@@ -1,0 +1,56 @@
+package org.petabytes.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.petabytes.api.source.local.AwesomeBlogsLocalSource;
+import org.petabytes.api.source.local.Feed;
+import org.petabytes.api.source.remote.AwesomeBlogsRemoteSource;
+
+import rx.Observable;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ApiTest {
+
+    private Api api;
+    private AwesomeBlogsLocalSource localSource;
+    private AwesomeBlogsRemoteSource remoteSource;
+
+    @Before
+    public void setUp() throws Exception {
+        localSource = mock(AwesomeBlogsLocalSource.class);
+        remoteSource = mock(AwesomeBlogsRemoteSource.class);
+        api = new Api(localSource, remoteSource);
+    }
+
+    @Test
+    public void getFeed_empty() throws Exception {
+        doReturn(Observable.<Feed>empty()).when(localSource).getFeed(anyString());
+        doReturn(Observable.just(new Feed())).when(remoteSource).getFeed(anyString());
+        api.getFeed("dev")
+            .test()
+            .awaitTerminalEvent()
+            .assertValueCount(1);
+
+        verify(localSource, times(1)).getFeed(anyString());
+        verify(remoteSource, times(1)).getFeed(anyString());
+    }
+    @Test
+    public void getFeed_one_more() throws Exception {
+        doReturn(Observable.just(new Feed())).when(localSource).getFeed(anyString());
+        doReturn(Observable.just(new Feed())).when(remoteSource).getFeed(anyString());
+        api.getFeed("dev")
+            .test()
+            .awaitTerminalEvent()
+            .assertValueCount(1);
+
+        verify(localSource, times(1)).getFeed(anyString());
+        verify(remoteSource, times(1)).getFeed(anyString());
+    }
+
+
+}


### PR DESCRIPTION
1. localsource 에서 null 반환 이 아닌 Observable.empty() 반환으로 변경

2. switchIfEmpty 를 이용하여 null empty 되는 경우를 제거함

#14 와 관련.